### PR TITLE
Support of gettxout api

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ bitcoin-cli getblockchaininfo
 - getblockheader <s>[verbose \ non verbose]</s>
 - <s>getmempoolinfo</s>
 - getrawtransaction [non verbose only]
-- <s>gettxout</s>
+- gettxout
 - <s>sendrawtransaction</s>
 
 

--- a/spruned/application/exceptions.py
+++ b/spruned/application/exceptions.py
@@ -8,3 +8,7 @@ class ServiceException(SprunedException):
 
 class HTTPClientException(SprunedException):
     pass
+
+
+class SpentTxOutException(SprunedException):
+    pass

--- a/spruned/services/bitpay_service.py
+++ b/spruned/services/bitpay_service.py
@@ -1,13 +1,16 @@
+from typing import Dict
+
 from spruned.application import settings
 from spruned.application.abstracts import RPCAPIService
 from spruned.services.http_client import HTTPClient
 
 
 class BitpayService(RPCAPIService):
-    def __init__(self, coin, httpclient=HTTPClient):
+    def __init__(self, coin, httpclient=HTTPClient, utxo_tracker=None):
         assert coin == settings.Network.BITCOIN
         self.client = httpclient(baseurl='https://insight.bitpay.com/api/')
         self.throttling_error_codes = []
+        self.utxo_tracker = utxo_tracker
 
     async def getrawtransaction(self, txid, **_):
         data = await self.get('tx/' + txid)
@@ -28,9 +31,39 @@ class BitpayService(RPCAPIService):
             'tx': None
         }
 
-    async def gettxout(self, txid, height):
-        """
-        https: // insight.bitpay.com / api / tx / 356ab5efacf7f9324f4bbb4c5bfbecf4df1f731acb70d20932c086478e875516
-        return enough infos on the output to have a gettxout api
-        """
-        pass
+    def _track_spents(self, data):
+        for i, _v in enumerate(data.get('vout', [])):
+            _v.get('spentTxId') and self.utxo_tracker.track_utxo_spent(
+                data['txid'],
+                i,
+                spent_by=_v.get('spentTxId'),
+                spent_at_index=_v.get('spentIndex'),
+                spent_at_height=_v.get('spentAtHeight')
+            )
+
+    @staticmethod
+    def _format_txout(data: Dict, index: int):
+        return {
+            "in_block": data.get("blockhash"),
+            "in_block_height": data.get("blockheight"),
+            "value_satoshi": int(float(data["vout"][index]["value"])*10**8),
+            "script_hex": data["vout"][index]["scriptPubKey"]["hex"],
+            "script_asm": data["vout"][index]["scriptPubKey"]["asm"],
+            "script_type": data["vout"][index]["scriptPubKey"]["type"],
+            "addresses": data["vout"][index]["scriptPubKey"].get("addresses", []),
+            "unspent": not bool(data["vout"][index]["spentTxId"])
+        }
+
+    async def gettxout(self, txid, index):
+        data = await self.get('tx/' + txid)
+        if not data or index >= len(data.get('vout', [])):
+            return
+        self.utxo_tracker and self._track_spents(data)
+        return self._format_txout(data, index)
+
+
+if __name__ == '__main__':
+    import asyncio
+    loop = asyncio.get_event_loop()
+    api = BitpayService(settings.NETWORK)
+    print(loop.run_until_complete(api.gettxout('8e4c29e2c37a1107f732492a94a94197bbbc6f93aa97b7b3e58852d42680b923', 0)))

--- a/spruned/services/blockcypher_service.py
+++ b/spruned/services/blockcypher_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import time
+from typing import Dict
 from spruned.application import settings
 from spruned.application.abstracts import RPCAPIService
 from spruned.application.tools import normalize_transaction
@@ -7,7 +8,7 @@ from spruned.services.http_client import HTTPClient
 
 
 class BlockCypherService(RPCAPIService):
-    def __init__(self, coin, api_token=None, httpclient=HTTPClient):
+    def __init__(self, coin, api_token=None, httpclient=HTTPClient, utxo_tracker=None):
         coin_url = {
             settings.Network.BITCOIN: 'btc/main/',
             settings.Network.BITCOIN_TESTNET: 'btc/testnet/'
@@ -16,6 +17,7 @@ class BlockCypherService(RPCAPIService):
         self._e_d = datetime(1970, 1, 1)
         self.api_token = api_token
         self.throttling_error_codes = []
+        self.utxo_tracker = utxo_tracker
 
     async def getrawtransaction(self, txid, **_):
         query = '?includeHex=1&limit=1'
@@ -57,9 +59,39 @@ class BlockCypherService(RPCAPIService):
             'tx': d['txids']
         }
 
+    def _track_spents(self, data):
+        for i, _v in enumerate(data.get('vout', [])):
+            _v.get('spent_by') and self.utxo_tracker.track_utxo_spent(
+                data['txid'],
+                i,
+                spent_by=_v.get('spent_by')
+            )
+
+    @staticmethod
+    def _format_txout(data: Dict, index: int):
+        return {
+            "in_block": data.get("block_hash"),
+            "in_block_height": data.get("block_height"),
+            "value_satoshi": data["outputs"][index]["value"],
+            "script_hex": data["outputs"][index]["script"],
+            "script_asm": None,
+            "script_type": data["outputs"][index]["script_type"],
+            "addresses": data["outputs"][index].get("addresses", []),
+            "unspent": not bool(data["outputs"][index].get("spent_by", False))
+        }
+
     async def gettxout(self, txid: str, index: int):
-        """
-        https://api.blockcypher.com/v1/btc/main/txs/f854aebae95150b379cc1187d848d58225f3c4157fe992bcd166f58bd5063449
-        there are enough infos to have gettxout
-        """
-        pass
+        query = '?includeHex=1&limit=1'
+        query = self.api_token and query + '&token=%s' % self.api_token or query
+        data = await self.get('txs/' + txid + query)
+        if not data or index >= len(data.get('outputs', [])):
+            return
+        self.utxo_tracker and self._track_spents(data)
+        return self._format_txout(data, index)
+
+
+if __name__ == '__main__':
+    import asyncio
+    loop = asyncio.get_event_loop()
+    api = BlockCypherService(settings.NETWORK, settings.BLOCKCYPHER_API_TOKEN)
+    print(loop.run_until_complete(api.gettxout('8e4c29e2c37a1107f732492a94a94197bbbc6f93aa97b7b3e58852d42680b923', 0)))

--- a/spruned/services/blockcypher_service.py
+++ b/spruned/services/blockcypher_service.py
@@ -68,14 +68,17 @@ class BlockCypherService(RPCAPIService):
             )
 
     @staticmethod
-    def _format_txout(data: Dict, index: int):
+    def _normalize_scripttype(script_type):
+        return {"pay-to-pubkey-hash": "pubkeyhash"}[script_type]
+
+    def _format_txout(self, data: Dict, index: int):
         return {
             "in_block": data.get("block_hash"),
             "in_block_height": data.get("block_height"),
             "value_satoshi": data["outputs"][index]["value"],
             "script_hex": data["outputs"][index]["script"],
             "script_asm": None,
-            "script_type": data["outputs"][index]["script_type"],
+            "script_type": self._normalize_scripttype(data["outputs"][index]["script_type"]),
             "addresses": data["outputs"][index].get("addresses", []),
             "unspent": not bool(data["outputs"][index].get("spent_by", False))
         }

--- a/spruned/services/blocktrail_service.py
+++ b/spruned/services/blocktrail_service.py
@@ -1,10 +1,12 @@
+from typing import Dict
+
 from spruned.application import settings
 from spruned.application.abstracts import RPCAPIService
 from spruned.services.http_client import HTTPClient
 
 
 class BlocktrailService(RPCAPIService):
-    def __init__(self, coin, api_key=None, httpclient=HTTPClient):
+    def __init__(self, coin, api_key=None, httpclient=HTTPClient, utxo_tracker=None):
         coin_url = {
             settings.NETWORK.BITCOIN: 'btc/'
         }[coin]
@@ -12,6 +14,7 @@ class BlocktrailService(RPCAPIService):
         assert api_key is not None
         self.api_key = api_key
         self.throttling_error_codes = []
+        self.utxo_tracker = utxo_tracker
 
     async def getrawtransaction(self, txid, **_):
         url = 'transaction/' + txid + '?api_key=' + self.api_key
@@ -34,8 +37,39 @@ class BlocktrailService(RPCAPIService):
             'tx': None
         }
 
-    async def gettxout(self):
-        """
-        blocktrail API permits to implement some sort of gettxout, yahi \o/
-        """
-        pass
+    def _track_spents(self, data):
+        for i, _v in enumerate(data.get('vout', [])):
+            _v.get('spent_hash') and self.utxo_tracker.track_utxo_spent(
+                data['hash'],
+                i,
+                spent_by=_v.get('spent_hash'),
+                spent_at_index=_v.get('spent_index'),
+            )
+
+    @staticmethod
+    def _format_txout(data: Dict, index: int):
+        return {
+            "in_block": data.get("blockhash"),
+            "in_block_height": data.get("blockheight"),
+            "value_satoshi": data["outputs"][index]["value"],
+            "script_hex": data["outputs"][index]["script_hex"],
+            "script_asm": data["outputs"][index]["script"],
+            "script_type": data["outputs"][index]["type"],
+            "addresses": [x for x in [data["outputs"][index].get("address", None)] if x is not None],
+            "unspent": not bool(data["outputs"][index]["spent_hash"])
+        }
+
+    async def gettxout(self, txid, index):
+        url = 'transaction/' + txid + '?api_key=' + self.api_key
+        data = await self.get(url)
+        if not data:
+            return
+        self.utxo_tracker and self._track_spents(data)
+        return self._format_txout(data, index)
+
+
+if __name__ == '__main__':
+    import asyncio
+    loop = asyncio.get_event_loop()
+    api = BlocktrailService(settings.NETWORK, api_key=settings.BLOCKTRAIL_API_KEY)
+    print(loop.run_until_complete(api.gettxout('8e4c29e2c37a1107f732492a94a94197bbbc6f93aa97b7b3e58852d42680b923', 0)))

--- a/spruned/services/chainso_service.py
+++ b/spruned/services/chainso_service.py
@@ -1,11 +1,13 @@
-from spruned.application import settings
+from typing import Dict
+
+from spruned.application import settings, exceptions
 from spruned.application.abstracts import RPCAPIService
 from spruned.application.tools import normalize_transaction
 from spruned.services.http_client import HTTPClient
 
 
 class ChainSoService(RPCAPIService):
-    def __init__(self, coin):
+    def __init__(self, coin, utxo_tracker=None):
         self._coin_url = {
             settings.Network.BITCOIN: 'BTC/'
         }[coin]
@@ -14,6 +16,7 @@ class ChainSoService(RPCAPIService):
         self.errors_ttl = 5
         self.max_errors_before_downtime = 1
         self.throttling_error_codes = (429, )
+        self.utxo_tracker = utxo_tracker
 
     async def getrawtransaction(self, txid, **_):
         data = await self.get('get_tx/' + self._coin_url + txid)
@@ -26,15 +29,48 @@ class ChainSoService(RPCAPIService):
 
     async def getblock(self, blockhash):
         print('getblock from %s' % self.__class__)
-        data = await self.client.get('get_block/' + self._coin_url + blockhash)
+        data = await self.get('get_block/' + self._coin_url + blockhash)
         return data and data.get('success') and {
             'source': 'chainso',
             'hash': data['data']['blockhash'],
             'tx': data['data']['txs']
         }
 
+    def _track_spents(self, data):
+        data.get('is_spent') and self.utxo_tracker.track_utxo_spent(
+            data['txid'],
+            data['output_no'],
+            spent_by=data['spent']['txid'],
+            spent_at_index=data['spent']['input_no']
+        )
+
+    @staticmethod
+    def _format_txout(_: Dict, __: int):
+        return {
+            "in_block": None,
+            "in_block_height": None,
+            "value_satoshi": None,
+            "script_hex": None,
+            "script_asm": None,
+            "script_type": None,
+            "addresses": None,
+            "unspent": True
+        }
+
     async def gettxout(self, txid: str, index: int):
         """
         https://chain.so/api#get-is-tx-output-spent
         """
-        pass
+        data = await self.get('is_tx_spent/' + self._coin_url + txid + '/' + str(index))
+        if not data.get('status') == 'success':
+            return
+        if data['data']['is_spent']:
+            self.utxo_tracker and self._track_spents(data)
+        return self._format_txout(data, index)
+
+
+if __name__ == '__main__':
+    import asyncio
+    loop = asyncio.get_event_loop()
+    api = ChainSoService(settings.NETWORK)
+    print(loop.run_until_complete(api.gettxout('8e4c29e2c37a1107f732492a94a94197bbbc6f93aa97b7b3e58852d42680b923', 0)))


### PR DESCRIPTION
Every request is made to remote services and not verified, a quorum algo may be applied, but with the default value min_sources=1, if the first query is complete, it's ok to return the value.

Will add electrum double check (addresses based).

Also, a "UtxoTracker" object is introduced in the third party services. This will track SPENTS to avoid querying remote services twice for a result we already know.

