### PR TITLE
systemd unit for sPRUNED

### DIFF
--- a/scripts/spruned.service
+++ b/scripts/spruned.service
@@ -1,0 +1,17 @@
+# sPRUNED: systemd unit
+# /etc/systemd/system/spruned.service
+
+[Unit]
+Description=sPRUNED Bitcoin node
+After=network.target
+
+[Service]
+# adjust path 
+ExecStart=/home/bitcoin/src/venv/bin/spruned
+Type=simple
+User=bitcoin
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
A ready-made systemd unit for spruned makes for reliable oprations. Tested on Ubuntu 16.04, but should be quite universal where systemd is used.