### PR TITLE
json-rpc: Map errors to an error code understood by bitcoin-cli

### DIFF
--- a/spruned/application/jsonrpc_server.py
+++ b/spruned/application/jsonrpc_server.py
@@ -22,7 +22,7 @@ spruned %s, emulating bitcoind %s
 
 == Blockchain ==
 getbestblockhash
-getblock "blockhash" ( verbosity ) 
+getblock "blockhash" ( verbosity )
 getblockchaininfo
 getblockcount
 getblockhash height
@@ -73,12 +73,13 @@ class JSONRPCServer:
             "result": None,
             "error": None
         }
+
         response = await methods.dispatch(request)
-        if isinstance(response, ExceptionResponse):
-            response['result'] = response.get('result', None)
-            return web.json_response(response, status=response.http_status)
         result.update(response)
-        return web.json_response(result)
+        if result['error'] and result['error']['code'] < -32:
+            result['error']['code'] = -1
+
+        return web.json_response(result, status=response.http_status)
 
     def run(self, main_loop):
         self.main_loop = main_loop

--- a/test/test_application/test_jsonrpc/test_getblock.py
+++ b/test/test_application/test_jsonrpc/test_getblock.py
@@ -81,8 +81,11 @@ class TestJSONRPCServerGetblock(TestCase):
                 'result': None
             }
         )
+
+        # Really should be code: -32602, but that'll cause bitcoin-cli not to
+        # error out correctly, so we use -1 instead
         self.assertEqual(
             res2,
-            {'jsonrpc': '2.0', 'error': {'code': -32602, 'message': 'Invalid params'}, 'id': 1, 'result': None}
+            {'jsonrpc': '2.0', 'error': {'code': -1, 'message': 'Invalid params'}, 'id': 1, 'result': None}
         )
         Mock.assert_not_called(self.vo_service.getblock)

--- a/test/test_application/test_jsonrpc/test_getblockhash.py
+++ b/test/test_application/test_jsonrpc/test_getblockhash.py
@@ -70,8 +70,10 @@ class TestJSONRPCServerGetblock(TestCase):
                 'result': None
             }
         )
+        # Really should be code: -32602, but that'll cause bitcoin-cli not to
+        # error out correctly, so we use -1 instead
         self.assertEqual(
             res2,
-            {'jsonrpc': '2.0', 'error': {'code': -32602, 'message': 'Invalid params'}, 'id': 1, 'result': None}
+            {'jsonrpc': '2.0', 'error': {'code': -1, 'message': 'Invalid params'}, 'id': 1, 'result': None}
         )
         Mock.assert_not_called(self.vo_service.getblock)

--- a/test/test_application/test_jsonrpc/test_getblockheader.py
+++ b/test/test_application/test_jsonrpc/test_getblockheader.py
@@ -114,8 +114,11 @@ class TestJSONRPCServerGetblockheader(TestCase):
                 'result': None
             }
         )
+
+        # Really should be code: -32602, but that'll cause bitcoin-cli not to
+        # error out correctly, so we use -1 instead
         self.assertEqual(
             res2,
-            {'jsonrpc': '2.0', 'error': {'code': -32602, 'message': 'Invalid params'}, 'id': 1, 'result': None}
+            {'jsonrpc': '2.0', 'error': {'code': -1, 'message': 'Invalid params'}, 'id': 1, 'result': None}
         )
         Mock.assert_not_called(self.vo_service.getblockheader)


### PR DESCRIPTION
bitcoin-cli will return different return codes depending on the error code in
the JSON-RPC response. This leads to crashes in c-lightning at least since
bitcoin-cli talking to spruned behaves differently (does not return a non-zero
return code) on some errors.

This fix just maps all the internal errors to the -1 error code which just
signals a generic temporary failure.