### PR TITLE
Bugfixing

### DIFF
--- a/spruned/app.py
+++ b/spruned/app.py
@@ -157,10 +157,13 @@ if sys.version > '3.5.2':  # pragma: no cover
             from spruned.application.logging_factory import Logger
             from spruned.application.database import sqlite
             from spruned.builder import repository
+
             migrations.run(sqlite)
 
             version = repository.blockchain.get_db_version()
-            if version != repository.blockchain.current_version:
+            if version != repository.blockchain.current_version and version != None:
+                print (version, repository.blockchain.current_version)
+                Logger.root.debug('Erasing database because of wrong version')
                 repository.blockchain.erase()
 
             if args.daemon:

--- a/spruned/app.py
+++ b/spruned/app.py
@@ -161,7 +161,7 @@ if sys.version > '3.5.2':  # pragma: no cover
             migrations.run(sqlite)
 
             version = repository.blockchain.get_db_version()
-            if version != repository.blockchain.current_version and version != None:
+            if version != repository.blockchain.current_version:
                 Logger.root.debug('Erasing database because of wrong version')
                 repository.blockchain.erase()
 

--- a/spruned/app.py
+++ b/spruned/app.py
@@ -162,7 +162,6 @@ if sys.version > '3.5.2':  # pragma: no cover
 
             version = repository.blockchain.get_db_version()
             if version != repository.blockchain.current_version and version != None:
-                print (version, repository.blockchain.current_version)
                 Logger.root.debug('Erasing database because of wrong version')
                 repository.blockchain.erase()
 

--- a/spruned/builder.py
+++ b/spruned/builder.py
@@ -50,8 +50,8 @@ def builder(ctx: Context):  # pragma: no cover
     blocks_reactor = BlocksReactor(repository, p2p_interface, keep_blocks=int(ctx.keep_blocks))
     headers_reactor.add_on_best_height_hit_persistent_callbacks(p2p_connectionpool.set_best_header)
     return jsonrpc_server, headers_reactor, blocks_reactor, repository, \
-           cache, zmq_context, zmq_observer, p2p_connectionpool
+           cache, zmq_context, zmq_observer, p2p_interface
 
 
 jsonrpc_server, headers_reactor, blocks_reactor, repository, \
-cache, zmq_context, zmq_observer, p2p_connectionpool = builder(_ctx)
+cache, zmq_context, zmq_observer, p2p_interface = builder(_ctx)

--- a/spruned/daemon/electrod/electrod_interface.py
+++ b/spruned/daemon/electrod/electrod_interface.py
@@ -139,7 +139,6 @@ class ElectrodInterface:
     async def get_merkleproof(self, txid: str, block_height: int):
         return await self.pool.call('blockchain.transaction.get_merkle', txid, block_height)
 
-            
     async def get_headers_in_range_from_chunks(self, starts_from: int, ends_to: int, get_peer=False):
         futures = []
         for chunk_index in range(starts_from, ends_to):

--- a/spruned/daemon/electrod/electrum_servers.json
+++ b/spruned/daemon/electrod/electrum_servers.json
@@ -126,7 +126,10 @@
   ],
   "bc_testnet": [
     ["electrumx.testnet.mempool.co", "s"],
-    ["electrumx.testnet.mempool.co", "t"]
+    ["electrumx.testnet.mempool.co", "t"],
+    ["tn.not.fyi", 5502],
+    ["testnet.hsmiths.com", 53012],
+    ["testnet1.bauerj.eu", 50002]
   ],
   "bc_regtest": []
 }

--- a/spruned/daemon/electrod/electrum_servers.json
+++ b/spruned/daemon/electrod/electrum_servers.json
@@ -125,6 +125,9 @@
     ["y4td57fxytoo5ki7.onion", "s"]
   ],
   "bc_testnet": [
+    ["tn.not.fyi", 5502],
+    ["testnet.hsmiths.com", 53012],
+    ["testnet1.bauerj.eu", 50002],
     ["electrumx.testnet.mempool.co", "s"],
     ["electrumx.testnet.mempool.co", "t"]
   ],

--- a/spruned/daemon/electrod/electrum_servers.json
+++ b/spruned/daemon/electrod/electrum_servers.json
@@ -125,9 +125,6 @@
     ["y4td57fxytoo5ki7.onion", "s"]
   ],
   "bc_testnet": [
-    ["tn.not.fyi", 5502],
-    ["testnet.hsmiths.com", 53012],
-    ["testnet1.bauerj.eu", 50002],
     ["electrumx.testnet.mempool.co", "s"],
     ["electrumx.testnet.mempool.co", "t"]
   ],

--- a/spruned/dependencies/connectrum.py
+++ b/spruned/dependencies/connectrum.py
@@ -395,7 +395,7 @@ class ServerInfo(dict):
         # Keep version and pruning limit separate
         #
         if isinstance(ports, int):
-            ports = ['t%d' % ports]
+            ports = ['s%d' % ports]
         elif isinstance(ports, str):
             ports = ports.split()
 
@@ -419,6 +419,7 @@ class ServerInfo(dict):
         self['pruning_limit'] = int(pruning_limit or 0)
 
         self['seen_at'] = time.time()
+
 
     @classmethod
     def from_dict(cls, d):
@@ -449,7 +450,8 @@ class ServerInfo(dict):
         Return (hostname, port number, ssl) pair for the protocol.
         Assuming only one port per host.
         """
-        assert len(for_protocol) == 1, "expect single letter code"
+        for_protocol = for_protocol[0]
+
         rv = [i[0] for i in self['ports'] if i[0] == for_protocol]
         port = None
         if len(rv) >= 2:
@@ -457,8 +459,8 @@ class ServerInfo(dict):
                 port = int(rv[1:])
             except:
                 pass
-        port = port or DEFAULT_PORTS[for_protocol]
-        use_ssl = for_protocol in ('s', 'g') or (type(port) == int and port % 2 == 0)
+        port = type(port) == int or DEFAULT_PORTS[for_protocol]
+        use_ssl = for_protocol in ('s', 'g')
         return self['hostname'], port, use_ssl
 
     @property

--- a/spruned/dependencies/connectrum.py
+++ b/spruned/dependencies/connectrum.py
@@ -458,7 +458,7 @@ class ServerInfo(dict):
             except:
                 pass
         port = port or DEFAULT_PORTS[for_protocol]
-        use_ssl = for_protocol in ('s', 'g')
+        use_ssl = for_protocol in ('s', 'g') or (type(port) == int and port % 2 == 0)
         return self['hostname'], port, use_ssl
 
     @property

--- a/spruned/dependencies/connectrum.py
+++ b/spruned/dependencies/connectrum.py
@@ -459,7 +459,7 @@ class ServerInfo(dict):
                 port = int(rv[1:])
             except:
                 pass
-        port = type(port) == int or DEFAULT_PORTS[for_protocol]
+        port = isinstance(port, int) or DEFAULT_PORTS[for_protocol]
         use_ssl = for_protocol in ('s', 'g')
         return self['hostname'], port, use_ssl
 

--- a/spruned/main.py
+++ b/spruned/main.py
@@ -16,6 +16,7 @@ async def main_task(loop):  # pragma: no cover
             await loop_check_integrity(loop)
         except asyncio.TimeoutError:
             Logger.cache.error('There must be an error in storage, 30 seconds to check are too many')
+
         Logger.leveldb.debug('Checking cache limits')
         try:
             await asyncio.wait_for(asyncio.gather(cache.check()), timeout=30)

--- a/spruned/main.py
+++ b/spruned/main.py
@@ -4,7 +4,7 @@ import gc
 import async_timeout
 
 from spruned.application.tools import async_delayed_task
-from spruned.builder import cache, headers_reactor, blocks_reactor, jsonrpc_server, repository, p2p_connectionpool
+from spruned.builder import cache, headers_reactor, blocks_reactor, jsonrpc_server, repository, p2p_interface
 
 
 async def main_task(loop):  # pragma: no cover
@@ -25,7 +25,7 @@ async def main_task(loop):  # pragma: no cover
         headers_reactor.add_on_new_header_callback(blocks_reactor.start)
         headers_reactor.add_on_best_height_hit_volatile_callbacks(blocks_reactor.bootstrap_blocks)
         loop.create_task(headers_reactor.start())
-        loop.create_task(p2p_connectionpool.connect())
+        loop.create_task(p2p_interface.start())
         loop.create_task(async_delayed_task(cache.lurk(), 600))
         loop.create_task(async_delayed_task(loop_collect_garbage(loop), 300))
     finally:

--- a/test/test_daemon/test_electrod/test_interface.py
+++ b/test/test_daemon/test_electrod/test_interface.py
@@ -153,19 +153,19 @@ class TestElectrodInterface(unittest.TestCase):
 
     def test_get_headers_in_range(self):
 
-        async def get_chunk(method, chunk, get_peer=False):
-            self.assertEqual(method, 'blockchain.block.get_chunk')
+        async def get_headers(method, chunk, get_peer=False):
+            self.assertEqual(method, 'blockchain.block.headers')
             bitcoind_header = "00000020fe52010fa7c798b97621508b772142dfc7b594df7a3a3200000000000000000097db2dc9" \
                               "4e2799bcdd7259f0876467b379fe44b69342df38a8ec2f350722f9a73367a95aa38955173732b883"
             i = {1: 2016, 2: 1024}
             return bitcoind_header * i[chunk]
 
-        self.connectionpool.call.side_effect = get_chunk
+        self.connectionpool.call.side_effect = get_headers
         res = self.loop.run_until_complete(self.sut.get_headers_in_range_from_chunks(1, 3))
         Mock.assert_has_calls(
             self.connectionpool.call,
-            calls=[call('blockchain.block.get_chunk', 1, get_peer=False),
-                   call('blockchain.block.get_chunk', 2, get_peer=False)],
+            calls=[call('blockchain.block.headers', 1 * 2016, get_peer=False),
+                   call('blockchain.block.headers', 2 * 2016, get_peer=False)],
             any_order=True
         )
         i = 0


### PR DESCRIPTION
- [x] Startup: Solve "Database is closed" error on clean .spruned firststart #85 

- [x] Electrum: Use headers() instead of deprecated (and removed) get_chunk() #86
 
- [x] Peers: solve latest no connection problem (it only occurs if p2p_peers.json) is empy or not existing #85. Since the p2p_pool.connect() only uses the p2p_pool.json file, if it does not exist it didn't bootstrap the p2p connections: to solve this, i call p2p_interface.start() (which implicity call p2p_pool.connect() btw) instead of p2p_pool.connect().